### PR TITLE
remove unused git submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "lib/jquerygantt"]
-	path = lib/jquerygantt
-	url = git@github.com:robicch/jQueryGantt.git


### PR DESCRIPTION
You should use bower or yarn/npm to fetch version of the dhtmlx/gantt package